### PR TITLE
ci: split linting and formatting checks into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,49 +33,8 @@ jobs:
       - name: 🎨 Run cargo fmt
         run: cargo fmt --all -- --check
 
-  lint:
-    name: 🔎 Lint (pg${{ matrix.pg_major }})
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        pg_major: [ 18 ]
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
-
-      - name: 🦀 Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: ⚡️ Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: lint-${{ matrix.pg_major }}-v3
-
-      - name: 🐘 Setup PostgreSQL Repository
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-common ca-certificates --no-install-recommends
-          sudo YES=1 /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-
-      - name: 📦 Cache & Install System Packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-        with:
-          packages: postgresql-${{ matrix.pg_major }} postgresql-server-dev-${{ matrix.pg_major }} clang gcc make pkg-config
-          version: pg${{ matrix.pg_major }}-lint-v1
-
-      - name: 🚀 Initialize PGRX
-        run: |
-          PGRX_VER=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '"' -f 2)
-          cargo install cargo-pgrx --version $PGRX_VER --locked
-          cargo pgrx init --pg${{ matrix.pg_major }} $(which pg_config)
-
-      - name: 🔎 Lint (Clippy)
-        run: cargo clippy --profile release -- -D warnings
-
   compile:
-    needs: [fmt, lint]
+    needs: fmt
     name: ⚙️ Compile (${{ matrix.arch }})
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     strategy:
@@ -111,6 +70,9 @@ jobs:
           PGRX_VER=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '"' -f 2)
           cargo install cargo-pgrx --version $PGRX_VER --locked
           cargo pgrx init --pg${{ matrix.pg_major }} $(which pg_config)
+
+      - name: 🔎 Lint (Clippy)
+        run: cargo clippy --profile release -- -D warnings
 
       - name: 🧪 Run Tests
         run: cargo pgrx test pg${{ matrix.pg_major }} --profile release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,64 @@ permissions:
   contents: read
 
 jobs:
+  fmt:
+    name: 🎨 Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🦀 Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: 🎨 Run cargo fmt
+        run: cargo fmt --all -- --check
+
+  lint:
+    name: 🔎 Lint (pg${{ matrix.pg_major }})
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        pg_major: [ 18 ]
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🦀 Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: ⚡️ Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: lint-${{ matrix.pg_major }}-v3
+
+      - name: 🐘 Setup PostgreSQL Repository
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-common ca-certificates --no-install-recommends
+          sudo YES=1 /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+
+      - name: 📦 Cache & Install System Packages
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        with:
+          packages: postgresql-${{ matrix.pg_major }} postgresql-server-dev-${{ matrix.pg_major }} clang gcc make pkg-config
+          version: pg${{ matrix.pg_major }}-lint-v1
+
+      - name: 🚀 Initialize PGRX
+        run: |
+          PGRX_VER=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '"' -f 2)
+          cargo install cargo-pgrx --version $PGRX_VER --locked
+          cargo pgrx init --pg${{ matrix.pg_major }} $(which pg_config)
+
+      - name: 🔎 Lint (Clippy)
+        run: cargo clippy --profile release -- -D warnings
+
   compile:
+    needs: [fmt, lint]
     name: ⚙️ Compile (${{ matrix.arch }})
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     strategy:
@@ -54,9 +111,6 @@ jobs:
           PGRX_VER=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '"' -f 2)
           cargo install cargo-pgrx --version $PGRX_VER --locked
           cargo pgrx init --pg${{ matrix.pg_major }} $(which pg_config)
-
-      - name: 🔎 Lint (Clippy)
-        run: cargo clippy --profile release -- -D warnings
 
       - name: 🧪 Run Tests
         run: cargo pgrx test pg${{ matrix.pg_major }} --profile release


### PR DESCRIPTION
On GitHub Actions, we split the linting (Clippy) and formatting (rustfmt) checks into separate jobs. This enables faster feedback on style and formatting issues without blocking on the slow build/test steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow with enhanced code quality checks, including dedicated format and linting verification steps that run before compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rixlhq/snowid-postgres/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->