### PR TITLE
feat!: release SnowID 3.0.0

### DIFF
--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -23,7 +23,13 @@ runs:
     - name: Resolve PGRX Version
       id: pgrx_version
       shell: bash
-      run: echo "value=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '\"' -f 2)" >> "$GITHUB_OUTPUT"
+      run: |
+        PGRX_VER="$(sed -n 's/^pgrx[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$GITHUB_WORKSPACE/Cargo.toml" | head -n1)"
+        if [ -z "$PGRX_VER" ]; then
+          echo "Could not resolve pgrx dependency version from $GITHUB_WORKSPACE/Cargo.toml" >&2
+          exit 1
+        fi
+        echo "value=$PGRX_VER" >> "$GITHUB_OUTPUT"
 
     - name: Setup PostgreSQL Repository
       shell: bash

--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -8,6 +8,9 @@ inputs:
   cache-key:
     description: Extra cache key segment for Rust dependency caching.
     required: true
+  pgrx-version:
+    description: cargo-pgrx version to install.
+    required: true
 
 runs:
   using: composite
@@ -19,17 +22,6 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ inputs.cache-key }}
-
-    - name: Resolve PGRX Version
-      id: pgrx_version
-      shell: bash
-      run: |
-        PGRX_VER="$(sed -n 's/^pgrx[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$GITHUB_WORKSPACE/Cargo.toml" | head -n1)"
-        if [ -z "$PGRX_VER" ]; then
-          echo "Could not resolve pgrx dependency version from $GITHUB_WORKSPACE/Cargo.toml" >&2
-          exit 1
-        fi
-        echo "value=$PGRX_VER" >> "$GITHUB_OUTPUT"
 
     - name: Setup PostgreSQL Repository
       shell: bash
@@ -48,12 +40,12 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cargo/bin/cargo-pgrx
-        key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ steps.pgrx_version.outputs.value }}
+        key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ inputs.pgrx-version }}
 
     - name: Install cargo-pgrx
       shell: bash
       run: |
-        PGRX_VER="${{ steps.pgrx_version.outputs.value }}"
+        PGRX_VER="${{ inputs.pgrx-version }}"
         INSTALLED_PGRX_VER="$(cargo-pgrx --version 2>/dev/null | awk '{print $2}' || true)"
         if [ "$INSTALLED_PGRX_VER" != "$PGRX_VER" ]; then
           cargo install cargo-pgrx --version "$PGRX_VER" --locked

--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -1,0 +1,58 @@
+name: Setup PGRX
+description: Install Rust, PostgreSQL, cargo-pgrx, and initialize pgrx for one PostgreSQL version.
+
+inputs:
+  pg-major:
+    description: PostgreSQL major version to initialize with pgrx.
+    required: true
+  cache-key:
+    description: Extra cache key segment for Rust dependency caching.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ inputs.cache-key }}
+
+    - name: Resolve PGRX Version
+      id: pgrx_version
+      shell: bash
+      run: echo "value=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '\"' -f 2)" >> "$GITHUB_OUTPUT"
+
+    - name: Setup PostgreSQL Repository
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y postgresql-common ca-certificates --no-install-recommends
+        sudo YES=1 /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+
+    - name: Cache & Install System Packages
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+      with:
+        packages: postgresql-${{ inputs.pg-major }} postgresql-server-dev-${{ inputs.pg-major }} clang gcc make pkg-config
+        version: pg${{ inputs.pg-major }}-${{ runner.arch }}-v1
+
+    - name: Cache cargo-pgrx Binary
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-pgrx
+        key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ steps.pgrx_version.outputs.value }}
+
+    - name: Install cargo-pgrx
+      shell: bash
+      run: |
+        PGRX_VER="${{ steps.pgrx_version.outputs.value }}"
+        INSTALLED_PGRX_VER="$(cargo-pgrx --version 2>/dev/null | awk '{print $2}' || true)"
+        if [ "$INSTALLED_PGRX_VER" != "$PGRX_VER" ]; then
+          cargo install cargo-pgrx --version "$PGRX_VER" --locked
+        fi
+
+    - name: Initialize PGRX
+      shell: bash
+      run: cargo pgrx init --pg${{ inputs.pg-major }} "$(which pg_config)"

--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -14,6 +14,8 @@ runs:
   steps:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -8,9 +8,6 @@ inputs:
   cache-key:
     description: Extra cache key segment for Rust dependency caching.
     required: true
-  pgrx-version:
-    description: cargo-pgrx version to install.
-    required: true
 
 runs:
   using: composite
@@ -22,6 +19,14 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ inputs.cache-key }}
+
+    - name: Resolve PGRX Version
+      id: pgrx_version
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        PGRX_VER=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '"' -f 2)
+        echo "value=$PGRX_VER" >> "$GITHUB_OUTPUT"
 
     - name: Setup PostgreSQL Repository
       shell: bash
@@ -40,12 +45,12 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cargo/bin/cargo-pgrx
-        key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ inputs.pgrx-version }}
+        key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ steps.pgrx_version.outputs.value }}
 
     - name: Install cargo-pgrx
       shell: bash
       run: |
-        PGRX_VER="${{ inputs.pgrx-version }}"
+        PGRX_VER="${{ steps.pgrx_version.outputs.value }}"
         INSTALLED_PGRX_VER="$(cargo-pgrx --version 2>/dev/null | awk '{print $2}' || true)"
         if [ "$INSTALLED_PGRX_VER" != "$PGRX_VER" ]; then
           cargo install cargo-pgrx --version "$PGRX_VER" --locked

--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -21,6 +21,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ inputs.cache-key }}
+        cache-on-failure: true
 
     - name: Resolve PGRX Version
       id: pgrx_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,16 @@ jobs:
           path: ~/.cargo/bin/cargo-pgrx
           key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ steps.pgrx_version.outputs.value }}
 
-      - name: 🚀 Initialize PGRX
+      - name: 🚀 Install cargo-pgrx
         run: |
           PGRX_VER="${{ steps.pgrx_version.outputs.value }}"
           INSTALLED_PGRX_VER="$(cargo-pgrx --version 2>/dev/null | awk '{print $2}' || true)"
           if [ "$INSTALLED_PGRX_VER" != "$PGRX_VER" ]; then
             cargo install cargo-pgrx --version "$PGRX_VER" --locked
           fi
+
+      - name: 🚀 Initialize PGRX
+        run: |
           cargo pgrx init --pg${{ matrix.pg_major }} $(which pg_config)
 
       - name: 🔎 Lint (Clippy)
@@ -134,7 +137,7 @@ jobs:
 
   build_and_push:
     name: 🐳 Build and Publish
-    if: ${{ github.event_name == 'workflow_call' && inputs.publish_images }}
+    if: ${{ inputs.publish_images }}
     needs: [fmt, compile]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
         with:
           key: ${{ matrix.arch }}-${{ matrix.pg_major }}-v3
 
+      - name: 🔖 Resolve PGRX Version
+        id: pgrx_version
+        run: echo "value=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '\"' -f 2)" >> "$GITHUB_OUTPUT"
+
       - name: 🐘 Setup PostgreSQL Repository
         run: |
           sudo apt-get update
@@ -77,22 +81,34 @@ jobs:
           packages: postgresql-${{ matrix.pg_major }} postgresql-server-dev-${{ matrix.pg_major }} clang gcc make pkg-config
           version: pg${{ matrix.pg_major }}-${{ matrix.arch }}-v1
 
+      - name: ⚡️ Cache cargo-pgrx Binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-pgrx
+          key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ steps.pgrx_version.outputs.value }}
+
       - name: 🚀 Initialize PGRX
         run: |
-          PGRX_VER=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '"' -f 2)
-          cargo install cargo-pgrx --version $PGRX_VER --locked
+          PGRX_VER="${{ steps.pgrx_version.outputs.value }}"
+          INSTALLED_PGRX_VER="$(cargo-pgrx --version 2>/dev/null | awk '{print $2}' || true)"
+          if [ "$INSTALLED_PGRX_VER" != "$PGRX_VER" ]; then
+            cargo install cargo-pgrx --version "$PGRX_VER" --locked
+          fi
           cargo pgrx init --pg${{ matrix.pg_major }} $(which pg_config)
 
       - name: 🔎 Lint (Clippy)
+        if: ${{ matrix.arch == 'amd64' }}
         run: cargo clippy --profile release -- -D warnings
 
       - name: 🧪 Run Tests
+        if: ${{ matrix.arch == 'amd64' }}
         run: cargo pgrx test pg${{ matrix.pg_major }} --profile release
 
       - name: 🔨 Build Extension
         run: cargo pgrx package --profile release
 
       - name: 🧪 Test Packaged SQL Files
+        if: ${{ matrix.arch == 'amd64' }}
         env:
           PG_SNOWID_PACKAGE_DIR: target/release/pg_snowid-pg${{ matrix.pg_major }}
         run: cargo test --test packaged_sql_files -- --ignored --nocapture
@@ -118,6 +134,7 @@ jobs:
 
   build_and_push:
     name: 🐳 Build and Publish
+    if: ${{ github.event_name == 'workflow_call' && inputs.publish_images }}
     needs: [fmt, compile]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,17 @@ jobs:
       - name: 🎨 Run cargo fmt
         run: cargo fmt --all -- --check
 
-  lint:
-    name: 🔎 Lint
+  validate:
+    name: ${{ matrix.check.name }}
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - name: 🔎 Lint
+            command: cargo clippy --profile release -- -D warnings
+          - name: 🧪 Test
+            command: cargo pgrx test pg18 --profile release
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
@@ -46,24 +54,8 @@ jobs:
           pg-major: 18
           cache-key: amd64-pg18-v4
 
-      - name: 🔎 Run Clippy
-        run: cargo clippy --profile release -- -D warnings
-
-  test:
-    name: 🧪 Test
-    runs-on: ubuntu-24.04
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
-
-      - name: 🚀 Setup PGRX
-        uses: ./.github/actions/setup-pgrx
-        with:
-          pg-major: 18
-          cache-key: amd64-pg18-v4
-
-      - name: 🧪 Run PGRX Tests
-        run: cargo pgrx test pg18 --profile release
+      - name: ${{ matrix.check.name }}
+        run: ${{ matrix.check.command }}
 
   package:
     name: 📦 Package (${{ matrix.arch }})
@@ -102,7 +94,7 @@ jobs:
   build_and_push:
     name: 🐳 Build and Publish
     if: ${{ inputs.publish_images }}
-    needs: [fmt, lint, test, package]
+    needs: [fmt, validate, package]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           pg-major: 18
           cache-key: amd64-pg18-v4
-          pgrx-version: 0.18.0
 
       - name: ${{ matrix.check.name }}
         run: ${{ matrix.check.command }}
@@ -62,7 +61,6 @@ jobs:
         with:
           pg-major: ${{ matrix.pg_major }}
           cache-key: ${{ matrix.arch }}-pg${{ matrix.pg_major }}-v4
-          pgrx-version: 0.18.0
 
       - name: 🔨 Build Extension
         run: cargo pgrx package --profile release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
       fail-fast: false
       matrix:
         check:
-          - name: 🎨 Format
-            cache-key: amd64-format-pg18-v5
+          - id: format
+            name: 🎨 Format
             command: cargo fmt --all -- --check
-          - name: 🔎 Lint
-            cache-key: amd64-lint-pg18-v5
+          - id: lint
+            name: 🔎 Lint
             command: cargo clippy --profile release -- -D warnings
-          - name: 🧪 Test
-            cache-key: amd64-test-pg18-v5
+          - id: test
+            name: 🧪 Test
             command: cargo pgrx test pg18 --profile release
     steps:
       - name: 📥 Checkout
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/setup-pgrx
         with:
           pg-major: 18
-          cache-key: ${{ matrix.check.cache-key }}
+          cache-key: validate-${{ matrix.check.id }}-pg18-v5
 
       - name: ${{ matrix.check.name }}
         run: ${{ matrix.check.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           pg-major: 18
           cache-key: amd64-pg18-v4
+          pgrx-version: 0.18.0
 
       - name: ${{ matrix.check.name }}
         run: ${{ matrix.check.command }}
@@ -71,6 +72,7 @@ jobs:
         with:
           pg-major: ${{ matrix.pg_major }}
           cache-key: ${{ matrix.arch }}-pg${{ matrix.pg_major }}-v4
+          pgrx-version: 0.18.0
 
       - name: 🔨 Build Extension
         run: cargo pgrx package --profile release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,6 @@ permissions:
   contents: read
 
 jobs:
-  fmt:
-    name: 🎨 Format
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v6
-
-      - name: 🦀 Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
-      - name: 🎨 Run cargo fmt
-        run: cargo fmt --all -- --check
-
   validate:
     name: ${{ matrix.check.name }}
     runs-on: ubuntu-24.04
@@ -40,15 +25,27 @@ jobs:
       fail-fast: false
       matrix:
         check:
+          - name: 🎨 Format
+            command: cargo fmt --all -- --check
+            requires-pgrx: false
           - name: 🔎 Lint
             command: cargo clippy --profile release -- -D warnings
+            requires-pgrx: true
           - name: 🧪 Test
             command: cargo pgrx test pg18 --profile release
+            requires-pgrx: true
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
 
+      - name: 🦀 Setup Rust
+        if: ${{ !matrix.check.requires-pgrx }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
       - name: 🚀 Setup PGRX
+        if: ${{ matrix.check.requires-pgrx }}
         uses: ./.github/actions/setup-pgrx
         with:
           pg-major: 18
@@ -94,7 +91,7 @@ jobs:
   build_and_push:
     name: 🐳 Build and Publish
     if: ${{ inputs.publish_images }}
-    needs: [fmt, validate, package]
+    needs: [validate, package]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ concurrency:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   fmt:
@@ -34,22 +33,43 @@ jobs:
       - name: 🎨 Run cargo fmt
         run: cargo fmt --all -- --check
 
-      - name: 🛑 Cancel Workflow on Failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            console.log('Canceling workflow due to format failure...');
-            await github.rest.actions.cancelWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId
-            });
+  lint:
+    name: 🔎 Lint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
 
-  compile:
-    name: ⚙️ Compile (${{ matrix.arch }})
+      - name: 🚀 Setup PGRX
+        uses: ./.github/actions/setup-pgrx
+        with:
+          pg-major: 18
+          cache-key: amd64-pg18-v4
+
+      - name: 🔎 Run Clippy
+        run: cargo clippy --profile release -- -D warnings
+
+  test:
+    name: 🧪 Test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v6
+
+      - name: 🚀 Setup PGRX
+        uses: ./.github/actions/setup-pgrx
+        with:
+          pg-major: 18
+          cache-key: amd64-pg18-v4
+
+      - name: 🧪 Run PGRX Tests
+        run: cargo pgrx test pg18 --profile release
+
+  package:
+    name: 📦 Package (${{ matrix.arch }})
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     strategy:
+      fail-fast: false
       matrix:
         pg_major: [ 18 ]
         arch: [ amd64, arm64 ]
@@ -57,55 +77,11 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v6
 
-      - name: 🦀 Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: ⚡️ Rust Cache
-        uses: Swatinem/rust-cache@v2
+      - name: 🚀 Setup PGRX
+        uses: ./.github/actions/setup-pgrx
         with:
-          key: ${{ matrix.arch }}-${{ matrix.pg_major }}-v3
-
-      - name: 🔖 Resolve PGRX Version
-        id: pgrx_version
-        run: echo "value=$(grep -m 1 '^pgrx = ' Cargo.toml | cut -d '\"' -f 2)" >> "$GITHUB_OUTPUT"
-
-      - name: 🐘 Setup PostgreSQL Repository
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-common ca-certificates --no-install-recommends
-          sudo YES=1 /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
-
-      - name: 📦 Cache & Install System Packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-        with:
-          packages: postgresql-${{ matrix.pg_major }} postgresql-server-dev-${{ matrix.pg_major }} clang gcc make pkg-config
-          version: pg${{ matrix.pg_major }}-${{ matrix.arch }}-v1
-
-      - name: ⚡️ Cache cargo-pgrx Binary
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ runner.os }}-${{ runner.arch }}-${{ steps.pgrx_version.outputs.value }}
-
-      - name: 🚀 Install cargo-pgrx
-        run: |
-          PGRX_VER="${{ steps.pgrx_version.outputs.value }}"
-          INSTALLED_PGRX_VER="$(cargo-pgrx --version 2>/dev/null | awk '{print $2}' || true)"
-          if [ "$INSTALLED_PGRX_VER" != "$PGRX_VER" ]; then
-            cargo install cargo-pgrx --version "$PGRX_VER" --locked
-          fi
-
-      - name: 🚀 Initialize PGRX
-        run: |
-          cargo pgrx init --pg${{ matrix.pg_major }} $(which pg_config)
-
-      - name: 🔎 Lint (Clippy)
-        if: ${{ matrix.arch == 'amd64' }}
-        run: cargo clippy --profile release -- -D warnings
-
-      - name: 🧪 Run Tests
-        if: ${{ matrix.arch == 'amd64' }}
-        run: cargo pgrx test pg${{ matrix.pg_major }} --profile release
+          pg-major: ${{ matrix.pg_major }}
+          cache-key: ${{ matrix.arch }}-pg${{ matrix.pg_major }}-v4
 
       - name: 🔨 Build Extension
         run: cargo pgrx package --profile release
@@ -123,24 +99,13 @@ jobs:
           path: target/release/pg_snowid-pg${{ matrix.pg_major }}/
           retention-days: 1
 
-      - name: 🛑 Cancel Workflow on Failure
-        if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            console.log('Canceling workflow due to compilation failure...');
-            await github.rest.actions.cancelWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId
-            });
-
   build_and_push:
     name: 🐳 Build and Publish
     if: ${{ inputs.publish_images }}
-    needs: [fmt, compile]
+    needs: [fmt, lint, test, package]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         pg_provider: [ pg, cloudnative-pg ]
         pg_version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@ jobs:
       matrix:
         check:
           - name: 🎨 Format
+            cache-key: amd64-format-pg18-v5
             command: cargo fmt --all -- --check
           - name: 🔎 Lint
+            cache-key: amd64-lint-pg18-v5
             command: cargo clippy --profile release -- -D warnings
           - name: 🧪 Test
+            cache-key: amd64-test-pg18-v5
             command: cargo pgrx test pg18 --profile release
     steps:
       - name: 📥 Checkout
@@ -39,7 +42,7 @@ jobs:
         uses: ./.github/actions/setup-pgrx
         with:
           pg-major: 18
-          cache-key: amd64-pg18-v4
+          cache-key: ${{ matrix.check.cache-key }}
 
       - name: ${{ matrix.check.name }}
         run: ${{ matrix.check.command }}
@@ -60,7 +63,7 @@ jobs:
         uses: ./.github/actions/setup-pgrx
         with:
           pg-major: ${{ matrix.pg_major }}
-          cache-key: ${{ matrix.arch }}-pg${{ matrix.pg_major }}-v4
+          cache-key: ${{ matrix.arch }}-package-pg${{ matrix.pg_major }}-v5
 
       - name: 🔨 Build Extension
         run: cargo pgrx package --profile release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,25 +27,15 @@ jobs:
         check:
           - name: 🎨 Format
             command: cargo fmt --all -- --check
-            requires-pgrx: false
           - name: 🔎 Lint
             command: cargo clippy --profile release -- -D warnings
-            requires-pgrx: true
           - name: 🧪 Test
             command: cargo pgrx test pg18 --profile release
-            requires-pgrx: true
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
 
-      - name: 🦀 Setup Rust
-        if: ${{ !matrix.check.requires-pgrx }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-
       - name: 🚀 Setup PGRX
-        if: ${{ matrix.check.requires-pgrx }}
         uses: ./.github/actions/setup-pgrx
         with:
           pg-major: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
   build_and_push:
     name: 🐳 Build and Publish
     if: ${{ inputs.publish_images }}
-    needs: [validate, package]
+    needs: [ validate, package ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -100,7 +100,8 @@ jobs:
         pg_version:
           - { major: 18, minor: 1, is_latest: false }
           - { major: 18, minor: 2, is_latest: false }
-          - { major: 18, minor: 3, is_latest: true }
+          - { major: 18, minor: 3, is_latest: false }
+          - { major: 18, minor: 4, is_latest: true }
 
     steps:
       - name: 📥 Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * SnowID 3.0.0: `generate()` now uses logical timestamp generation by default and always returns an ID instead of waiting for the next millisecond when the sequence range is exhausted. This significantly improves performance under high load.
 * expose SnowID 3.0 non-blocking `try_generate` and batch generation APIs for PostgreSQL callers.
 
+### Bug Fixes
+
+* initialize the documented default node ID explicitly and require custom node IDs to be set before generators are created.
+
 ## [2.4.0](https://github.com/rixlhq/snowid-postgres/compare/v2.3.8...v2.4.0) (2026-05-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * SnowID 3.0.0: `generate()` now uses logical timestamp generation by default and always returns an ID instead of waiting for the next millisecond when the sequence range is exhausted. This significantly improves performance under high load.
+* expose SnowID 3.0 non-blocking `try_generate` and batch generation APIs for PostgreSQL callers.
 
 ## [2.4.0](https://github.com/rixlhq/snowid-postgres/compare/v2.3.8...v2.4.0) (2026-05-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.0](https://github.com/rixlhq/snowid-postgres/compare/v2.4.0...v3.0.0) (2026-05-23)
+
+### Features
+
+* SnowID 3.0.0: `generate()` now uses logical timestamp generation by default and always returns an ID instead of waiting for the next millisecond when the sequence range is exhausted. This significantly improves performance under high load.
+
 ## [2.4.0](https://github.com/rixlhq/snowid-postgres/compare/v2.3.8...v2.4.0) (2026-05-21)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "pg_snowid"
-version = "2.4.0"
+version = "3.0.0"
 dependencies = [
  "heapless",
  "pgrx",
@@ -1442,9 +1442,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snowid"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e986b197ecd687acbdc58a0416c11b9d3b83aa385969236b3c6994448a4a8"
+checksum = "e1712b3993dda5eaa0c6d79e9bbf757142a44bd4babdef597b3488d5eef07621"
 dependencies = [
  "base62",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_snowid"
-version = "2.4.0"
+version = "3.0.0"
 edition = "2024"
 resolver = "3"
 rust-version = "1.95"
@@ -29,7 +29,7 @@ pg_test = []
 
 [dependencies]
 pgrx = "0.18.0"
-snowid = "2.1.0"
+snowid = "3.0.0"
 heapless = "0.9.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ When one generator exhausts the current millisecond's sequence range, it no long
 
 This removes the previous hot-path wait under bursty write load and can significantly improve generation throughput. Keep table IDs distributed across tables or shards when possible, because each table ID maps to its own shared generator.
 
+If you need wall-clock-only generation, use the `try_*` functions. They return `NULL` instead of advancing logical time when the current millisecond is exhausted or when the generator is already ahead of wall-clock time:
+
+```sql
+SELECT snowid_try_generate(1);
+SELECT snowid_try_generate_base62(1);
+```
+
+For bulk inserts or reservation-heavy paths, use batch generation. `snowid_generate_batch` always returns the requested number of IDs and may advance logical time. `snowid_try_generate_batch` returns only the IDs that can be reserved immediately without logical timestamp advancement.
+
+```sql
+SELECT unnest(snowid_generate_batch(1, 1000));
+SELECT unnest(snowid_try_generate_batch(1, 1000));
+```
+
 ## 🔧 Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ SELECT snowid_get_timestamp_base62('2qPfVQh7Jw9');
 SELECT snowid_stats();
 ```
 
+### PostgreSQL Functions
+
+| Function | Returns | Description |
+| --- | --- | --- |
+| `snowid_set_node(node smallint)` | `void` | Sets the node ID for this PostgreSQL instance. |
+| `snowid_get_node()` | `smallint` | Returns the current node ID. |
+| `snowid_generate(table_id oid)` | `bigint` | Generates one logical timestamp SnowID. |
+| `snowid_generate_base62(table_id oid)` | `text` | Generates one logical timestamp SnowID encoded as Base62. |
+| `snowid_try_generate(table_id oid)` | `bigint` or `NULL` | Generates one ID only when available without logical timestamp advancement. |
+| `snowid_try_generate_base62(table_id oid)` | `text` or `NULL` | Generates one Base62 ID only when available without logical timestamp advancement. |
+| `snowid_generate_batch(table_id oid, count int)` | `bigint[]` | Generates `count` IDs with logical batch reservation. |
+| `snowid_try_generate_batch(table_id oid, count int)` | `bigint[]` | Returns only IDs immediately available without logical timestamp advancement. |
+| `snowid_get_timestamp(id bigint)` | `bigint` | Extracts the timestamp component from a numeric SnowID. |
+| `snowid_get_timestamp_base62(encoded_id text)` | `bigint` | Extracts the timestamp component from a Base62 SnowID. |
+| `snowid_stats()` | `text` | Returns generator and node statistics. |
+
 ### High-Load Generation Behavior
 
 `pg_snowid` uses SnowID 3.0's default logical timestamp generation through `snowid_generate(...)` and `snowid_generate_base62(...)`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > A PostgreSQL extension for generating Snowflake-like IDs using [snowid](https://crates.io/crates/snowid) Rust library.
 
 **Generate 64-bit unique identifiers in PostgreSQL that are:**
-- ⚡️ Fast (~244ns per ID)
+- ⚡️ Fast with SnowID 3.0 logical timestamp generation
 - 📈 Time-sorted
 - 🔄 Monotonic
 - 🔒 Thread-safe
@@ -38,15 +38,15 @@ Example: "2qPfVQh7Jw9"
 <details>
 <summary><b>Docker Image</b></summary>
 
-Use our pre-built PostgreSQL 17 image with SnowID extension:
+Use our pre-built PostgreSQL 18 image with SnowID extension:
 
 ```bash
-docker pull rixl/snowid-pg:17
-docker run -e POSTGRES_PASSWORD=postgres -p 5432:5432 qeeqez/snowid-pg:17
+docker pull rixl/snowid-pg:18
+docker run -e POSTGRES_PASSWORD=postgres -p 5432:5432 rixl/snowid-pg:18
 ```
 
 The image comes with:
-- PostgreSQL 17
+- PostgreSQL 18
 - SnowID extension installed
 - `shared_preload_libraries` configured
 </details>
@@ -126,6 +126,14 @@ SELECT snowid_get_timestamp_base62('2qPfVQh7Jw9');
 -- View SnowID statistics
 SELECT snowid_stats();
 ```
+
+### High-Load Generation Behavior
+
+`pg_snowid` uses SnowID 3.0's default logical timestamp generation through `snowid_generate(...)` and `snowid_generate_base62(...)`.
+
+When one generator exhausts the current millisecond's sequence range, it no longer waits for the next wall-clock millisecond. Instead, it advances the timestamp component logically and returns an ID immediately. IDs remain unique, time-sorted, and monotonic for that generator, while the embedded timestamp can run ahead of wall-clock time during sustained overload.
+
+This removes the previous hot-path wait under bursty write load and can significantly improve generation throughput. Keep table IDs distributed across tables or shards when possible, because each table ID maps to its own shared generator.
 
 ## 🔧 Development
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ SELECT snowid_set_node(5);
 SELECT snowid_get_node();
 ```
 
+If you do not call `snowid_set_node`, the extension uses the fixed default node ID `1`. This value is not auto-generated from the host or PostgreSQL instance. In multi-node deployments, set a unique node ID on every instance before generating IDs; otherwise different instances using the same node ID can produce overlapping ID ranges.
+
 ### Create Table with SnowID
 
 ```sql
@@ -131,7 +133,7 @@ SELECT snowid_stats();
 
 | Function | Returns | Description |
 | --- | --- | --- |
-| `snowid_set_node(node smallint)` | `void` | Sets the node ID for this PostgreSQL instance. |
+| `snowid_set_node(node smallint)` | `void` | Sets the node ID for this PostgreSQL instance before generators are created. |
 | `snowid_get_node()` | `smallint` | Returns the current node ID. |
 | `snowid_generate(table_id oid)` | `bigint` | Generates one logical timestamp SnowID. |
 | `snowid_generate_base62(table_id oid)` | `text` | Generates one logical timestamp SnowID encoded as Base62. |

--- a/images/cloudnative-pg/Dockerfile
+++ b/images/cloudnative-pg/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_MAJOR=18
-ARG PG_MINOR=1
+ARG PG_MINOR=4
 
 FROM ghcr.io/cloudnative-pg/postgresql:${PG_MAJOR}.${PG_MINOR}-standard-trixie
 

--- a/images/dev/Dockerfile
+++ b/images/dev/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_MAJOR=18
-ARG PG_MINOR=1
+ARG PG_MINOR=4
 ARG PGRX=0.18.0
 
 FROM postgres:${PG_MAJOR}.${PG_MINOR}-trixie AS builder

--- a/images/pg/Dockerfile
+++ b/images/pg/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_MAJOR=18
-ARG PG_MINOR=1
+ARG PG_MINOR=4
 
 FROM postgres:${PG_MAJOR}.${PG_MINOR}-trixie
 

--- a/pg_snowid.control
+++ b/pg_snowid.control
@@ -1,6 +1,6 @@
 comment = 'Generate Snowflake-like IDs with speed and thread-safety in PostgreSQL'
 # x-release-please-start-version
-default_version = '2.4.0'
+default_version = '3.0.0'
 # x-release-please-end
 module_pathname = '$libdir/pg_snowid'
 relocatable = false

--- a/sql/pg_snowid--2.4.0--3.0.0.sql
+++ b/sql/pg_snowid--2.4.0--3.0.0.sql
@@ -1,0 +1,1 @@
+-- Upgrade script for pg_snowid from version 2.4.0 to 3.0.0

--- a/sql/pg_snowid--2.4.0--3.0.0.sql
+++ b/sql/pg_snowid--2.4.0--3.0.0.sql
@@ -1,1 +1,62 @@
 -- Upgrade script for pg_snowid from version 2.4.0 to 3.0.0
+-- Adds SnowID 3.0 non-blocking and batch generation functions.
+
+CREATE FUNCTION "snowid_generate_batch"(
+    "table_id" oid,
+    "count" INT
+) RETURNS bigint[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_generate_batch_wrapper';
+
+CREATE FUNCTION "snowid_generate_batch_int"(
+    "table_id" INT,
+    "count" INT
+) RETURNS bigint[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_generate_batch_int_wrapper';
+
+CREATE FUNCTION "snowid_try_generate"(
+    "table_id" oid
+) RETURNS bigint
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_try_generate_wrapper';
+
+CREATE FUNCTION "snowid_try_generate_int"(
+    "table_id" INT
+) RETURNS bigint
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_try_generate_int_wrapper';
+
+CREATE FUNCTION "snowid_try_generate_base62"(
+    "table_id" oid
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_try_generate_base62_wrapper';
+
+CREATE FUNCTION "snowid_try_generate_base62_int"(
+    "table_id" INT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_try_generate_base62_int_wrapper';
+
+CREATE FUNCTION "snowid_try_generate_batch"(
+    "table_id" oid,
+    "count" INT
+) RETURNS bigint[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_try_generate_batch_wrapper';
+
+CREATE FUNCTION "snowid_try_generate_batch_int"(
+    "table_id" INT,
+    "count" INT
+) RETURNS bigint[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'snowid_try_generate_batch_int_wrapper';

--- a/sql/pg_snowid--2.4.0--3.0.0.sql
+++ b/sql/pg_snowid--2.4.0--3.0.0.sql
@@ -9,27 +9,12 @@ STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'snowid_generate_batch_wrapper';
 
-CREATE FUNCTION "snowid_generate_batch_int"(
-    "table_id" INT,
-    "count" INT
-) RETURNS bigint[]
-STRICT
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'snowid_generate_batch_int_wrapper';
-
 CREATE FUNCTION "snowid_try_generate"(
     "table_id" oid
 ) RETURNS bigint
 STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'snowid_try_generate_wrapper';
-
-CREATE FUNCTION "snowid_try_generate_int"(
-    "table_id" INT
-) RETURNS bigint
-STRICT
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'snowid_try_generate_int_wrapper';
 
 CREATE FUNCTION "snowid_try_generate_base62"(
     "table_id" oid
@@ -38,13 +23,6 @@ STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'snowid_try_generate_base62_wrapper';
 
-CREATE FUNCTION "snowid_try_generate_base62_int"(
-    "table_id" INT
-) RETURNS TEXT
-STRICT
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'snowid_try_generate_base62_int_wrapper';
-
 CREATE FUNCTION "snowid_try_generate_batch"(
     "table_id" oid,
     "count" INT
@@ -52,11 +30,3 @@ CREATE FUNCTION "snowid_try_generate_batch"(
 STRICT
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'snowid_try_generate_batch_wrapper';
-
-CREATE FUNCTION "snowid_try_generate_batch_int"(
-    "table_id" INT,
-    "count" INT
-) RETURNS bigint[]
-STRICT
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'snowid_try_generate_batch_int_wrapper';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,17 +15,12 @@ pg_module_magic!();
 
 const MAX_TABLES: usize = 1024;
 const MAX_BATCH_SIZE: i32 = 100_000;
+const DEFAULT_NODE_ID: i16 = 1;
 
 #[derive(Debug)]
 struct SharedSnowID(SnowID);
 
 unsafe impl PGRXSharedMemory for SharedSnowID {}
-
-impl Default for SharedSnowID {
-    fn default() -> Self {
-        Self(SnowID::new(1).unwrap())
-    }
-}
 
 // SAFETY: C-string literals are null-terminated and valid for static initialization
 static NODE_ID: PgAtomic<AtomicI16> = unsafe { PgAtomic::new(c"NODE_ID") };
@@ -33,12 +28,15 @@ static GENERATORS: PgLwLock<AssertPGRXSharedMemory<FnvIndexMap<i32, SharedSnowID
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
-    pg_shmem_init!(NODE_ID);
+    pg_shmem_init!(NODE_ID = AtomicI16::new(DEFAULT_NODE_ID));
     // heapless containers require explicit initialization via AssertPGRXSharedMemory wrapper
     pg_shmem_init!(GENERATORS = unsafe { AssertPGRXSharedMemory::new(FnvIndexMap::default()) });
 }
 
 /// Sets node ID (0-1023) for this `PostgreSQL` instance
+///
+/// The node ID defaults to 1 and is not auto-derived from the host. Set a
+/// unique node before generating IDs in multi-node deployments.
 ///
 /// @param node - Node ID between 0 and 1023
 /// @example SELECT `snowid_set_node`(5);
@@ -46,6 +44,14 @@ pub extern "C-unwind" fn _PG_init() {
 fn snowid_set_node(node: i16) {
     if !(0..=1023).contains(&node) {
         error!("Node ID must be between 0 and 1023");
+    }
+    let current_node = NODE_ID.get().load(Ordering::Relaxed);
+    if current_node == node {
+        return;
+    }
+    let generators = GENERATORS.exclusive();
+    if !generators.is_empty() {
+        error!("Node ID must be set before generating IDs; restart PostgreSQL to change it after generators have been created");
     }
     NODE_ID.get().store(node, Ordering::Relaxed);
 }
@@ -173,6 +179,10 @@ fn validate_batch_count(count: i32) -> usize {
     usize::try_from(count).unwrap()
 }
 
+fn default_snowid() -> SnowID {
+    SnowID::new(u16::try_from(DEFAULT_NODE_ID).unwrap()).unwrap()
+}
+
 /// Helper function to create a generator for a table
 fn create_generator_for_table(generators: &mut FnvIndexMap<i32, SharedSnowID, MAX_TABLES>, table_id: i32) {
     let node_id = NODE_ID.get().load(Ordering::Relaxed);
@@ -215,7 +225,7 @@ fn snowid_get_timestamp(id: i64) -> i64 {
     }
     let id_u64: u64 = u64::try_from(id).unwrap();
 
-    with_any_generator(|sid| sid.extract.timestamp(id_u64).try_into().unwrap())
+    default_snowid().extract.timestamp(id_u64).try_into().unwrap()
 }
 
 /// Gets timestamp from base62-encoded `SnowID`
@@ -225,36 +235,10 @@ fn snowid_get_timestamp(id: i64) -> i64 {
 /// @example SELECT `snowid_get_timestamp_base62`('2qPfVQh7Jw9');
 #[pg_extern]
 fn snowid_get_timestamp_base62(encoded_id: &str) -> i64 {
-    with_any_generator(|sid| match sid.decode_base62(encoded_id) {
-        Ok(id) => sid.extract.timestamp(id).try_into().unwrap(),
+    match base62::decode(encoded_id) {
+        Ok(id) => default_snowid().extract.timestamp(id).try_into().unwrap(),
         Err(e) => error!("Failed to decode base62 ID: {}", e),
-    })
-}
-
-/// Ensures there is at least one generator and runs the provided function with it.
-fn with_any_generator<R>(f: impl Fn(&SnowID) -> R) -> R {
-    // Fast path under shared lock
-    let generators_shared = GENERATORS.share();
-    if let Some((_, generator)) = generators_shared.iter().next() {
-        return f(&generator.0);
     }
-    drop(generators_shared);
-
-    // Slow path: create a default generator under exclusive lock if needed
-    let mut generators = GENERATORS.exclusive();
-    if generators.is_empty() {
-        let node_id = NODE_ID.get().load(Ordering::Relaxed);
-        let Ok(snowid) = SnowID::new(u16::try_from(node_id).unwrap()) else {
-            error!("Failed to create default generator for node {}", node_id);
-        };
-        let shared_snowid = SharedSnowID(snowid);
-        if generators.insert(0, shared_snowid).is_err() {
-            error!("Failed to insert default generator");
-        }
-    }
-
-    let (_, generator) = generators.iter().next().unwrap();
-    f(&generator.0)
 }
 
 /// Shows `SnowID` statistics (generators, `table_id`s, node ID)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,10 @@ fn snowid_generate(table_id: pg_sys::Oid) -> i64 {
 
 /// Generates unique `SnowID` for given table
 ///
+/// Uses SnowID's default logical timestamp generation. When the current
+/// millisecond's sequence range is exhausted, generation advances the timestamp
+/// component instead of waiting for the next wall-clock millisecond.
+///
 /// @param `table_id` - Unique positive integer ID for the table
 /// @returns 64-bit unique time-sorted identifier
 /// @example CREATE TABLE users (id bigint PRIMARY KEY DEFAULT `snowid_generate`(1));
@@ -83,6 +87,8 @@ fn snowid_generate_base62(table_id: pg_sys::Oid) -> String {
 }
 
 /// Generates unique base62-encoded `SnowID` for given table
+///
+/// Uses the same logical timestamp generation behavior as `snowid_generate`.
 ///
 /// @param `table_id` - Unique positive integer ID for the table
 /// @returns base62-encoded unique time-sorted identifier (VARCHAR(11))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,14 @@ use pgrx::pg_shmem_init;
 use pgrx::prelude::{error, pg_extern, pg_guard, pg_module_magic, pg_sys};
 use pgrx::shmem::AssertPGRXSharedMemory;
 use pgrx::shmem::PGRXSharedMemory;
-use snowid::SnowID;
+use snowid::{SnowID, base62};
 use std::fmt::Write as _;
 use std::sync::atomic::{AtomicI16, Ordering};
 
 pg_module_magic!();
 
 const MAX_TABLES: usize = 1024;
+const MAX_BATCH_SIZE: i32 = 100_000;
 
 #[derive(Debug)]
 struct SharedSnowID(SnowID);
@@ -82,6 +83,84 @@ fn snowid_generate_int(table_id: i32) -> i64 {
 }
 
 #[pg_extern]
+fn snowid_try_generate(table_id: pg_sys::Oid) -> Option<i64> {
+    snowid_try_generate_int(table_id.to_u32().try_into().unwrap())
+}
+
+/// Tries to generate a unique `SnowID` for given table without logical timestamp advancement
+///
+/// Returns `NULL` instead of advancing the logical timestamp when the current
+/// wall-clock millisecond's sequence range is exhausted or the generator's
+/// logical timestamp is already ahead of wall-clock time.
+///
+/// @param `table_id` - Unique positive integer ID for the table
+/// @returns 64-bit unique time-sorted identifier, or NULL when unavailable immediately
+/// @example SELECT `snowid_try_generate`(1);
+#[pg_extern]
+fn snowid_try_generate_int(table_id: i32) -> Option<i64> {
+    if table_id <= 0 {
+        error!("Table ID must be a positive number");
+    }
+
+    with_table_generator(table_id, |sid| sid.try_generate().ok().map(|id| id.try_into().unwrap()))
+}
+
+#[pg_extern]
+fn snowid_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
+    snowid_generate_batch_int(table_id.to_u32().try_into().unwrap(), count)
+}
+
+/// Generates a batch of unique `SnowID`s for given table
+///
+/// Uses SnowID's logical batch reservation. It always returns `count` IDs and
+/// may advance timestamp components instead of waiting under sustained load.
+///
+/// @param `table_id` - Unique positive integer ID for the table
+/// @param count - Number of IDs to generate
+/// @returns Array of 64-bit unique time-sorted identifiers
+/// @example SELECT unnest(`snowid_generate_batch`(1, 1000));
+#[pg_extern]
+fn snowid_generate_batch_int(table_id: i32, count: i32) -> Vec<i64> {
+    if table_id <= 0 {
+        error!("Table ID must be a positive number");
+    }
+
+    let count = validate_batch_count(count);
+    let mut ids = vec![0_u64; count];
+    with_table_generator(table_id, |sid| {
+        sid.generate_batch(&mut ids);
+    });
+    ids.into_iter().map(|id| id.try_into().unwrap()).collect()
+}
+
+#[pg_extern]
+fn snowid_try_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
+    snowid_try_generate_batch_int(table_id.to_u32().try_into().unwrap(), count)
+}
+
+/// Tries to generate a batch of unique `SnowID`s without logical timestamp advancement
+///
+/// Returns as many IDs as can be reserved immediately from the wall-clock
+/// millisecond. The returned array can contain fewer than `count` IDs.
+///
+/// @param `table_id` - Unique positive integer ID for the table
+/// @param count - Maximum number of IDs to generate
+/// @returns Array of immediately available 64-bit unique time-sorted identifiers
+/// @example SELECT unnest(`snowid_try_generate_batch`(1, 1000));
+#[pg_extern]
+fn snowid_try_generate_batch_int(table_id: i32, count: i32) -> Vec<i64> {
+    if table_id <= 0 {
+        error!("Table ID must be a positive number");
+    }
+
+    let count = validate_batch_count(count);
+    let mut ids = vec![0_u64; count];
+    let written = with_table_generator(table_id, |sid| sid.try_generate_batch(&mut ids));
+    ids.truncate(written);
+    ids.into_iter().map(|id| id.try_into().unwrap()).collect()
+}
+
+#[pg_extern]
 fn snowid_generate_base62(table_id: pg_sys::Oid) -> String {
     snowid_generate_base62_int(table_id.to_u32().try_into().unwrap())
 }
@@ -102,6 +181,38 @@ fn snowid_generate_base62_int(table_id: i32) -> String {
     with_table_generator(table_id, SnowID::generate_base62)
 }
 
+#[pg_extern]
+fn snowid_try_generate_base62(table_id: pg_sys::Oid) -> Option<String> {
+    snowid_try_generate_base62_int(table_id.to_u32().try_into().unwrap())
+}
+
+/// Tries to generate a base62-encoded `SnowID` without logical timestamp advancement
+///
+/// Returns `NULL` instead of advancing the logical timestamp when an ID cannot
+/// be generated immediately from wall-clock time.
+///
+/// @param `table_id` - Unique positive integer ID for the table
+/// @returns base62-encoded unique time-sorted identifier, or NULL when unavailable immediately
+/// @example SELECT `snowid_try_generate_base62`(1);
+#[pg_extern]
+fn snowid_try_generate_base62_int(table_id: i32) -> Option<String> {
+    if table_id <= 0 {
+        error!("Table ID must be a positive number");
+    }
+
+    with_table_generator(table_id, |sid| sid.try_generate().ok().map(base62::encode))
+}
+
+fn validate_batch_count(count: i32) -> usize {
+    if count < 0 {
+        error!("Batch count must be non-negative");
+    }
+    if count > MAX_BATCH_SIZE {
+        error!("Batch count must not exceed {}", MAX_BATCH_SIZE);
+    }
+    usize::try_from(count).unwrap()
+}
+
 /// Helper function to create a generator for a table
 fn create_generator_for_table(generators: &mut FnvIndexMap<i32, SharedSnowID, MAX_TABLES>, table_id: i32) {
     let node_id = NODE_ID.get().load(Ordering::Relaxed);
@@ -116,7 +227,7 @@ fn create_generator_for_table(generators: &mut FnvIndexMap<i32, SharedSnowID, MA
 
 /// Runs the provided function with a generator for the given table id.
 /// Creates the generator if it doesn't exist using a double-checked locking pattern.
-fn with_table_generator<R>(table_id: i32, f: impl Fn(&SnowID) -> R) -> R {
+fn with_table_generator<R>(table_id: i32, mut f: impl FnMut(&SnowID) -> R) -> R {
     // Fast path under shared lock
     let generators_shared = GENERATORS.share();
     if let Some(generator) = generators_shared.get(&table_id) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,6 @@ fn snowid_get_node() -> i16 {
     NODE_ID.get().load(Ordering::Relaxed)
 }
 
-#[pg_extern]
-fn snowid_generate(table_id: pg_sys::Oid) -> i64 {
-    snowid_generate_int(table_id.to_u32().try_into().unwrap())
-}
-
 /// Generates unique `SnowID` for given table
 ///
 /// Uses SnowID's default logical timestamp generation. When the current
@@ -74,17 +69,9 @@ fn snowid_generate(table_id: pg_sys::Oid) -> i64 {
 /// @returns 64-bit unique time-sorted identifier
 /// @example CREATE TABLE users (id bigint PRIMARY KEY DEFAULT `snowid_generate`(1));
 #[pg_extern]
-fn snowid_generate_int(table_id: i32) -> i64 {
-    if table_id <= 0 {
-        error!("Table ID must be a positive number");
-    }
-
+fn snowid_generate(table_id: pg_sys::Oid) -> i64 {
+    let table_id = table_oid_to_id(table_id);
     with_table_generator(table_id, |sid| sid.generate().try_into().unwrap())
-}
-
-#[pg_extern]
-fn snowid_try_generate(table_id: pg_sys::Oid) -> Option<i64> {
-    snowid_try_generate_int(table_id.to_u32().try_into().unwrap())
 }
 
 /// Tries to generate a unique `SnowID` for given table without logical timestamp advancement
@@ -97,17 +84,9 @@ fn snowid_try_generate(table_id: pg_sys::Oid) -> Option<i64> {
 /// @returns 64-bit unique time-sorted identifier, or NULL when unavailable immediately
 /// @example SELECT `snowid_try_generate`(1);
 #[pg_extern]
-fn snowid_try_generate_int(table_id: i32) -> Option<i64> {
-    if table_id <= 0 {
-        error!("Table ID must be a positive number");
-    }
-
+fn snowid_try_generate(table_id: pg_sys::Oid) -> Option<i64> {
+    let table_id = table_oid_to_id(table_id);
     with_table_generator(table_id, |sid| sid.try_generate().ok().map(|id| id.try_into().unwrap()))
-}
-
-#[pg_extern]
-fn snowid_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
-    snowid_generate_batch_int(table_id.to_u32().try_into().unwrap(), count)
 }
 
 /// Generates a batch of unique `SnowID`s for given table
@@ -120,22 +99,14 @@ fn snowid_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
 /// @returns Array of 64-bit unique time-sorted identifiers
 /// @example SELECT unnest(`snowid_generate_batch`(1, 1000));
 #[pg_extern]
-fn snowid_generate_batch_int(table_id: i32, count: i32) -> Vec<i64> {
-    if table_id <= 0 {
-        error!("Table ID must be a positive number");
-    }
-
+fn snowid_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
+    let table_id = table_oid_to_id(table_id);
     let count = validate_batch_count(count);
     let mut ids = vec![0_u64; count];
     with_table_generator(table_id, |sid| {
         sid.generate_batch(&mut ids);
     });
     ids.into_iter().map(|id| id.try_into().unwrap()).collect()
-}
-
-#[pg_extern]
-fn snowid_try_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
-    snowid_try_generate_batch_int(table_id.to_u32().try_into().unwrap(), count)
 }
 
 /// Tries to generate a batch of unique `SnowID`s without logical timestamp advancement
@@ -148,21 +119,13 @@ fn snowid_try_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
 /// @returns Array of immediately available 64-bit unique time-sorted identifiers
 /// @example SELECT unnest(`snowid_try_generate_batch`(1, 1000));
 #[pg_extern]
-fn snowid_try_generate_batch_int(table_id: i32, count: i32) -> Vec<i64> {
-    if table_id <= 0 {
-        error!("Table ID must be a positive number");
-    }
-
+fn snowid_try_generate_batch(table_id: pg_sys::Oid, count: i32) -> Vec<i64> {
+    let table_id = table_oid_to_id(table_id);
     let count = validate_batch_count(count);
     let mut ids = vec![0_u64; count];
     let written = with_table_generator(table_id, |sid| sid.try_generate_batch(&mut ids));
     ids.truncate(written);
     ids.into_iter().map(|id| id.try_into().unwrap()).collect()
-}
-
-#[pg_extern]
-fn snowid_generate_base62(table_id: pg_sys::Oid) -> String {
-    snowid_generate_base62_int(table_id.to_u32().try_into().unwrap())
 }
 
 /// Generates unique base62-encoded `SnowID` for given table
@@ -173,17 +136,9 @@ fn snowid_generate_base62(table_id: pg_sys::Oid) -> String {
 /// @returns base62-encoded unique time-sorted identifier (VARCHAR(11))
 /// @example CREATE TABLE users (id VARCHAR(11) PRIMARY KEY DEFAULT `snowid_generate_base62`(1));
 #[pg_extern]
-fn snowid_generate_base62_int(table_id: i32) -> String {
-    if table_id <= 0 {
-        error!("Table ID must be a positive number");
-    }
-
+fn snowid_generate_base62(table_id: pg_sys::Oid) -> String {
+    let table_id = table_oid_to_id(table_id);
     with_table_generator(table_id, SnowID::generate_base62)
-}
-
-#[pg_extern]
-fn snowid_try_generate_base62(table_id: pg_sys::Oid) -> Option<String> {
-    snowid_try_generate_base62_int(table_id.to_u32().try_into().unwrap())
 }
 
 /// Tries to generate a base62-encoded `SnowID` without logical timestamp advancement
@@ -195,12 +150,17 @@ fn snowid_try_generate_base62(table_id: pg_sys::Oid) -> Option<String> {
 /// @returns base62-encoded unique time-sorted identifier, or NULL when unavailable immediately
 /// @example SELECT `snowid_try_generate_base62`(1);
 #[pg_extern]
-fn snowid_try_generate_base62_int(table_id: i32) -> Option<String> {
+fn snowid_try_generate_base62(table_id: pg_sys::Oid) -> Option<String> {
+    let table_id = table_oid_to_id(table_id);
+    with_table_generator(table_id, |sid| sid.try_generate().ok().map(base62::encode))
+}
+
+fn table_oid_to_id(table_id: pg_sys::Oid) -> i32 {
+    let table_id = table_id.to_u32().try_into().unwrap();
     if table_id <= 0 {
         error!("Table ID must be a positive number");
     }
-
-    with_table_generator(table_id, |sid| sid.try_generate().ok().map(base62::encode))
+    table_id
 }
 
 fn validate_batch_count(count: i32) -> usize {


### PR DESCRIPTION
## Summary
- Bump `pg_snowid` and the bundled `snowid` dependency to `3.0.0`
- Document SnowID 3.0 logical timestamp generation in the README and PostgreSQL function docs
- `snowid_generate(...)` and `snowid_generate_base62(...)` now return immediately when a millisecond sequence range is exhausted, advancing the timestamp component logically instead of waiting for the next wall-clock millisecond
- Add PostgreSQL wrappers for SnowID 3.0 non-blocking and batch APIs: `snowid_try_generate`, `snowid_try_generate_base62`, `snowid_generate_batch`, and `snowid_try_generate_batch`
- Remove redundant exported `_int` SQL wrappers so the extension exposes only the intended OID-based public PostgreSQL functions
- Make node ID initialization explicit: default is fixed node ID `1`, it is not auto-generated from the host, and custom node IDs must be set before generators are created
- Update README coverage for all exposed PostgreSQL functions and update the `2.4.0 -> 3.0.0` migration script to create the new public functions for existing installations
- Keep IDs unique, time-sorted, and monotonic while noting that embedded timestamps can run ahead of wall-clock time during sustained overload
- Refresh PostgreSQL 18.4 image references and continue CI cleanup with shared pgrx setup and parallel validation/package jobs

## Breaking Change
- SnowID generation semantics changed under per-millisecond sequence exhaustion: generation no longer waits for the next millisecond and can advance logical timestamp components ahead of wall-clock time.
- Redundant `_int` SQL helper functions are no longer exported; use the public OID-based `snowid_*` functions.
- Changing the node ID after generators have been created is rejected; configure a unique node ID before generating IDs in multi-node deployments.

## Testing
- `cargo fetch`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `cargo pgrx package --profile release`
- `cargo test --test packaged_sql_files -- --ignored`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/release.yml`
